### PR TITLE
fix: upgrading @readme/openapi-parser to fix a rare npm install issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,17 +26,6 @@
         "node": "^12 || ^14 || ^16"
       }
     },
-    "node_modules/@apidevtools/json-schema-ref-parser": {
-      "version": "0.0.0-dev",
-      "resolved": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-      "license": "MIT",
-      "dependencies": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "node_modules/@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
@@ -2056,6 +2045,17 @@
         "prettier": "^2.0.2"
       }
     },
+    "node_modules/@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
     "node_modules/@readme/oas-examples": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
@@ -2063,15 +2063,15 @@
       "dev": true
     },
     "node_modules/@readme/openapi-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.0.tgz",
-      "integrity": "sha512-pa5zWTU6Xp3TOI6fMDtbmEv5bF3w8ThFNtvMROiQyIMFAfge4q6QTLU6KiGLOjfW/QcuHV6reRApmAyyY0cjFw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
       "dependencies": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
         "ajv": "^8.6.3",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"
@@ -11194,16 +11194,6 @@
     }
   },
   "dependencies": {
-    "@apidevtools/json-schema-ref-parser": {
-      "version": "git+ssh://git@github.com/erunion/json-schema-ref-parser.git#402904c92c8465db788be70655c3773c6e42a051",
-      "from": "@apidevtools/json-schema-ref-parser@github:erunion/json-schema-ref-parser#fix/dates-as-strings",
-      "requires": {
-        "@jsdevtools/ono": "^7.1.3",
-        "@types/json-schema": "^7.0.6",
-        "call-me-maybe": "^1.0.1",
-        "js-yaml": "^4.1.0"
-      }
-    },
     "@apidevtools/openapi-schemas": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/@apidevtools/openapi-schemas/-/openapi-schemas-2.1.0.tgz",
@@ -12789,6 +12779,17 @@
         "eslint-plugin-you-dont-need-lodash-underscore": "^6.12.0"
       }
     },
+    "@readme/json-schema-ref-parser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/json-schema-ref-parser/-/json-schema-ref-parser-1.0.0.tgz",
+      "integrity": "sha512-M3b8E4l6+MGFyhznQoQ1yoVFkre8vQEkk9doGGp4okHAwYLikwZRKeC/UWp88cGbr8+ZB1a7pMmHu2iteDWmPg==",
+      "requires": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.6",
+        "call-me-maybe": "^1.0.1",
+        "js-yaml": "^4.1.0"
+      }
+    },
     "@readme/oas-examples": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/@readme/oas-examples/-/oas-examples-4.3.2.tgz",
@@ -12796,15 +12797,15 @@
       "dev": true
     },
     "@readme/openapi-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.0.tgz",
-      "integrity": "sha512-pa5zWTU6Xp3TOI6fMDtbmEv5bF3w8ThFNtvMROiQyIMFAfge4q6QTLU6KiGLOjfW/QcuHV6reRApmAyyY0cjFw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@readme/openapi-parser/-/openapi-parser-1.2.1.tgz",
+      "integrity": "sha512-WNOJypM5UTiTXZmQUU416bX2z5enrA3gLd7ZJC/SszMyvQjW/ygOJjonJ3I+X9uRQhxGIDV/zgcKDtx3m0Zfng==",
       "requires": {
-        "@apidevtools/json-schema-ref-parser": "github:erunion/json-schema-ref-parser#fix/dates-as-strings",
         "@apidevtools/openapi-schemas": "^2.1.0",
         "@apidevtools/swagger-methods": "^3.0.2",
         "@jsdevtools/ono": "^7.1.3",
         "@readme/better-ajv-errors": "^1.1.0",
+        "@readme/json-schema-ref-parser": "^1.0.0",
         "ajv": "^8.6.3",
         "ajv-draft-04": "^1.0.0",
         "call-me-maybe": "^1.0.1"


### PR DESCRIPTION
## 🧰 Changes

Upgrades `@readme/openapi-parser` to fix a rare NPM installation issue in certain environments with a dependency of it.

This fix is in support of readmeio/rdme#401.

## 🧬 QA & Testing

If tests pass this is good to go.