### PR TITLE
feat: parsing out the postman collection version for `.version()`

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -320,21 +320,21 @@ describe('#version', () => {
 
   it('should detect a Postman collection', async () => {
     await expect(
-      new OASNormalize(require.resolve('@readme/oas-examples/2.0/json/petstore.json'), { enablePaths: true }).version()
-    ).resolves.toStrictEqual({
-      specification: 'swagger',
-      version: '2.0',
-    });
-  });
-
-  it('should detect a Swagger definition', async () => {
-    await expect(
       new OASNormalize(require.resolve('./__fixtures__/postman/petstore.collection.json'), {
         enablePaths: true,
       }).version()
     ).resolves.toStrictEqual({
       specification: 'postman',
-      version: 'unknown',
+      version: '2.1.0',
+    });
+  });
+
+  it('should detect a Swagger definition', async () => {
+    await expect(
+      new OASNormalize(require.resolve('@readme/oas-examples/2.0/json/petstore.json'), { enablePaths: true }).version()
+    ).resolves.toStrictEqual({
+      specification: 'swagger',
+      version: '2.0',
     });
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -215,7 +215,7 @@ export default class OASNormalize {
           let version = 'unknown';
           if (schema?.info?.schema) {
             const match = schema.info.schema.match(
-              /http(s?):\/\/schema.getpostman.com\/json\/collection\/v([0-9.]+)\/collection.json/
+              /http(s?):\/\/schema.getpostman.com\/json\/collection\/v([0-9.]+)\//
             );
 
             if (match) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,10 +212,20 @@ export default class OASNormalize {
           };
 
         case 'postman':
-          // We don't have any way right now to know if a Postman collection is for v2.0 or v2.1.
+          let version = 'unknown';
+          if (schema?.info?.schema) {
+            const match = schema.info.schema.match(
+              /http(s?):\/\/schema.getpostman.com\/json\/collection\/v([0-9.]+)\/collection.json/
+            );
+
+            if (match) {
+              version = match[2];
+            }
+          }
+
           return {
             specification: 'postman',
-            version: 'unknown',
+            version,
           };
 
         case 'swagger':


### PR DESCRIPTION
## 🧰 Changes

`info.schema` is required for Postman collections but there's no strictness around its contents. We've seen that it /usually/ follows this format so we can do our best to get a version, otherwise we'll fallback to treat it as `unknown`.

https://schema.postman.com/json/collection/v2.0.0/collection.json
https://schema.postman.com/json/collection/v2.1.0/collection.json