### PR TITLE
fix: stricter type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -29,7 +29,7 @@ export default class OASNormalize {
 
   opts: Options;
 
-  type: boolean | string;
+  type: ReturnType<typeof utils.getType>;
 
   constructor(file: any, opts?: Options) {
     this.file = file;


### PR DESCRIPTION
## 🧰 Changes

As part of the work I'm doing in https://github.com/readmeio/rdme/pull/735 I'm using the `type` value that's used in the `OASNormalize` class. This PR gives the `type` value a stricter TS type.

## 🧬 QA & Testing

I `npm link`'d it to `rdme` and confirmed the stricter type is surfaced properly:

<img width="926" alt="CleanShot 2023-01-31 at 12 11 38@2x" src="https://user-images.githubusercontent.com/8854718/215846942-13c7d8ee-93c3-4e70-8650-18e778d8439a.png">

