### PR TITLE
feat: swapping out `postman-to-openapi` for our fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ await oas.deref().then(definition => {
 
 Validate and optionally convert to OpenAPI, a given API definition. This supports Swagger 2.0, OpenAPI 3.x API definitions as well as Postman 2.x collections.
 
-Please note that if you've supplied a Postman collection to the library it will **always** be converted to OpenAPI, using [postman-to-openapi](https://github.com/joolfe/postman-to-openapi), and we will only validate resulting OpenAPI definition.
+Please note that if you've supplied a Postman collection to the library it will **always** be converted to OpenAPI, using [@readme/postman-to-openapi](https://npm.im/@readme/postman-to-openapi), and we will only validate resulting OpenAPI definition.
 
 ```js
 await oas.validate().then(definition => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
       "license": "MIT",
       "dependencies": {
         "@readme/openapi-parser": "^2.4.0",
+        "@readme/postman-to-openapi": "^4.0.0",
         "js-yaml": "^4.1.0",
         "node-fetch": "^2.6.1",
         "openapi-types": "^12.1.0",
-        "postman-to-openapi": "^3.0.1",
         "swagger2openapi": "^7.0.8"
       },
       "devDependencies": {
@@ -1744,6 +1744,21 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "node_modules/@readme/postman-to-openapi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/postman-to-openapi/-/postman-to-openapi-4.0.0.tgz",
+      "integrity": "sha512-LOwlzby87Njj6k6OofCmWSsl+EcnZjKp/wBQe/Loqxi+2m4TGnpALRP62zFjHw23ZUTVZvst8PIF6LMsK8xUHw==",
+      "dependencies": {
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "marked": "^4.2.12",
+        "mustache": "^4.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.25.21",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
@@ -2887,14 +2902,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
-      "engines": {
-        "node": ">= 12"
       }
     },
     "node_modules/comment-parser": {
@@ -7562,9 +7569,9 @@
       }
     },
     "node_modules/marked": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
-      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ==",
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw==",
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -8211,25 +8218,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/postman-to-openapi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/postman-to-openapi/-/postman-to-openapi-3.0.1.tgz",
-      "integrity": "sha512-OUenC7fi5moe41nhO0yUj8jqVj6tchLCjPxG2d28Ai//Oujt3lL7tiFCL2P6pKUV1a7p5X/BJh7op65jjbrs3Q==",
-      "dependencies": {
-        "commander": "^8.3.0",
-        "js-yaml": "^4.1.0",
-        "jsonc-parser": "3.2.0",
-        "lodash.camelcase": "^4.3.0",
-        "marked": "^4.2.5",
-        "mustache": "^4.2.0"
-      },
-      "bin": {
-        "p2o": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=14 <20"
       }
     },
     "node_modules/prettier": {
@@ -10825,6 +10813,18 @@
         }
       }
     },
+    "@readme/postman-to-openapi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/postman-to-openapi/-/postman-to-openapi-4.0.0.tgz",
+      "integrity": "sha512-LOwlzby87Njj6k6OofCmWSsl+EcnZjKp/wBQe/Loqxi+2m4TGnpALRP62zFjHw23ZUTVZvst8PIF6LMsK8xUHw==",
+      "requires": {
+        "js-yaml": "^4.1.0",
+        "jsonc-parser": "3.2.0",
+        "lodash.camelcase": "^4.3.0",
+        "marked": "^4.2.12",
+        "mustache": "^4.2.0"
+      }
+    },
     "@sinclair/typebox": {
       "version": "0.25.21",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.25.21.tgz",
@@ -11675,11 +11675,6 @@
       "requires": {
         "delayed-stream": "~1.0.0"
       }
-    },
-    "commander": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
-      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="
     },
     "comment-parser": {
       "version": "1.3.1",
@@ -15116,9 +15111,9 @@
       }
     },
     "marked": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.5.tgz",
-      "integrity": "sha512-jPueVhumq7idETHkb203WDD4fMA3yV9emQ5vLwop58lu8bTclMghBWcYAavlDqIEMaisADinV1TooIFCfqOsYQ=="
+      "version": "4.2.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.12.tgz",
+      "integrity": "sha512-yr8hSKa3Fv4D3jdZmtMMPghgVt6TWbk86WQaWhDloQjRSQhMMYCAro7jP7VDJrjjdV8pxVxMssXS8B8Y5DZ5aw=="
     },
     "merge-stream": {
       "version": "2.0.0",
@@ -15596,19 +15591,6 @@
       "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-8.0.0.tgz",
       "integrity": "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==",
       "dev": true
-    },
-    "postman-to-openapi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/postman-to-openapi/-/postman-to-openapi-3.0.1.tgz",
-      "integrity": "sha512-OUenC7fi5moe41nhO0yUj8jqVj6tchLCjPxG2d28Ai//Oujt3lL7tiFCL2P6pKUV1a7p5X/BJh7op65jjbrs3Q==",
-      "requires": {
-        "commander": "^8.3.0",
-        "js-yaml": "^4.1.0",
-        "jsonc-parser": "3.2.0",
-        "lodash.camelcase": "^4.3.0",
-        "marked": "^4.2.5",
-        "mustache": "^4.2.0"
-      }
     },
     "prettier": {
       "version": "2.8.4",

--- a/package.json
+++ b/package.json
@@ -43,10 +43,10 @@
   "license": "MIT",
   "dependencies": {
     "@readme/openapi-parser": "^2.4.0",
+    "@readme/postman-to-openapi": "^4.0.0",
     "js-yaml": "^4.1.0",
     "node-fetch": "^2.6.1",
     "openapi-types": "^12.1.0",
-    "postman-to-openapi": "^3.0.1",
     "swagger2openapi": "^7.0.8"
   },
   "devDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,8 @@ import type { OpenAPI } from 'openapi-types';
 import fs from 'fs';
 
 import openapiParser from '@readme/openapi-parser';
+import postmanToOpenAPI from '@readme/postman-to-openapi';
 import fetch from 'node-fetch';
-import postmanToOpenAPI from 'postman-to-openapi';
 
 import converter from 'swagger2openapi';
 


### PR DESCRIPTION
## 🧰 Changes

As we have a number of fixes we need made to [postman-to-openapi](https://npm.im/postman-to-openapi) I've forked the library and have swapped out the implementation here with that.