### PR TITLE
fix: parse data in YAML files into JSONSchema-compatible data types

### DIFF
--- a/__tests__/__fixtures__/quirks/yaml-date.yaml
+++ b/__tests__/__fixtures__/quirks/yaml-date.yaml
@@ -1,0 +1,12 @@
+openapi: 3.0.0
+servers:
+  - url: https://httpbin.org
+info:
+  version: 2015-04-22T10:03:19.323-07:00
+  title: YAML spec with a date string as a version
+paths:
+  '/anything':
+    get:
+      responses:
+        '200':
+          description: OK

--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -107,6 +107,16 @@ describe('#load', () => {
       );
     });
   });
+
+  describe('quirks', () => {
+    it('should not convert date strings in YAML files into Date objects', async () => {
+      const yaml = require.resolve('./__fixtures__/quirks/yaml-date.yaml');
+      const o = new OASNormalize(fs.readFileSync(yaml, 'utf8'));
+
+      const s = await o.load();
+      expect(typeof s.info.version).toBe('string');
+    });
+  });
 });
 
 describe('#bundle', () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,5 +1,4 @@
-import YAML from 'js-yaml';
-
+import YAML, { JSON_SCHEMA } from 'js-yaml';
 /**
  * Determine if a given variable is a `Buffer`.
  *
@@ -90,7 +89,7 @@ export function stringToJSON(string: string | Record<string, unknown>) {
     return JSON.parse(string);
   }
 
-  return YAML.load(string);
+  return YAML.load(string, { schema: JSON_SCHEMA });
 }
 
 /**


### PR DESCRIPTION
| 🚥 Fixes https://github.com/readmeio/rdme/issues/778 |
| :---------------- |

## 🧰 Changes

This fixes a bug surfaced in https://github.com/readmeio/rdme/issues/778 where [js-yaml](https://npm.im/js-yaml), by default, parses strings that look like dates into JS `Date` objects. I had fixed this same issue in our JSON Schema `$ref` parser in https://github.com/readmeio/json-schema-ref-parser/pull/1 but that only applies to parsing JSON Schema, and not in this case, `info.version` strings.
