### PR TITLE
fix: use of `files` to cleanup the package size

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,9 @@
   "engines": {
     "node": ">=14"
   },
+  "files": [
+    "dist"
+  ],
   "keywords": [
     "api",
     "apidoc",


### PR DESCRIPTION
| 🚥  https://github.com/readmeio/oas/pull/793 |
| :------------------- |

## 🧰 Changes

I was just trying out the Bun test runner and noticed a bug(probably in Bun itself). Bun test was importing a d.t.s which is part of the oas-normalize package: https://github.com/readmeio/oas-normalize/blob/main/src/.sink.d.ts.

This is of course fine but then I was wondering with the change done here we only can import package.json and files in the dist folder(ESM). So why not add files or add src to the .npmIgnore file?

This will reduce the size of the package(duplicated code) and make sure that we import from dist instead of src.

## 🧬 QA & Testing

Before `files`
```
npm notice 
npm notice 📦  oas-normalize@9.0.0
npm notice === Tarball Contents === 
npm notice 1.1kB   LICENSE.md                 
npm notice 4.7kB   README.md                  
npm notice 2.1kB   dist/chunk-F3S2V53P.js     
npm notice 4.4kB   dist/chunk-F3S2V53P.js.map 
npm notice 1.8kB   dist/chunk-UA3RGTRU.mjs    
npm notice 4.4kB   dist/chunk-UA3RGTRU.mjs.map
npm notice 1.8kB   dist/index.d.mts           
npm notice 1.8kB   dist/index.d.ts            
npm notice 6.2kB   dist/index.js              
npm notice 11.2kB  dist/index.js.map          
npm notice 5.5kB   dist/index.mjs             
npm notice 11.2kB  dist/index.mjs.map         
npm notice 2.0kB   dist/lib/utils.d.mts       
npm notice 2.0kB   dist/lib/utils.d.ts        
npm notice 1.3kB   dist/lib/utils.js          
npm notice 51B     dist/lib/utils.js.map      
npm notice 225B    dist/lib/utils.mjs         
npm notice 51B     dist/lib/utils.mjs.map     
npm notice 2.1MB   docs/github_logo_raw.png   
npm notice 133.3kB docs/github_logo_small.png 
npm notice 392.4kB docs/logo.png              
npm notice 2.1kB   package.json               
npm notice 129B    src/.sink.d.ts             
npm notice 7.4kB   src/index.ts               
npm notice 3.0kB   src/lib/utils.ts           
npm notice 355B    tsconfig.json              
npm notice 447B    tsup.config.ts             
npm notice === Tarball Details === 
npm notice name:          oas-normalize                           
npm notice version:       9.0.0                                   
npm notice filename:      oas-normalize-9.0.0.tgz                 
npm notice package size:  2.6 MB                                  
npm notice unpacked size: 2.7 MB                                  
npm notice shasum:        d708082cb259c609e57348e20be8277e66b881ab
npm notice integrity:     sha512-udGLsENrguvwu[...]AF20MCr/wR0NA==
npm notice total files:   27                                      
```

After `files`
```
npm notice 
npm notice 📦  oas-normalize@9.0.0
npm notice === Tarball Contents === 
npm notice 1.1kB  LICENSE.md                 
npm notice 4.7kB  README.md                  
npm notice 2.1kB  dist/chunk-F3S2V53P.js     
npm notice 4.4kB  dist/chunk-F3S2V53P.js.map 
npm notice 1.8kB  dist/chunk-UA3RGTRU.mjs    
npm notice 4.4kB  dist/chunk-UA3RGTRU.mjs.map
npm notice 1.8kB  dist/index.d.mts           
npm notice 1.8kB  dist/index.d.ts            
npm notice 6.2kB  dist/index.js              
npm notice 11.2kB dist/index.js.map          
npm notice 5.5kB  dist/index.mjs             
npm notice 11.2kB dist/index.mjs.map         
npm notice 2.0kB  dist/lib/utils.d.mts       
npm notice 2.0kB  dist/lib/utils.d.ts        
npm notice 1.3kB  dist/lib/utils.js          
npm notice 51B    dist/lib/utils.js.map      
npm notice 225B   dist/lib/utils.mjs         
npm notice 51B    dist/lib/utils.mjs.map     
npm notice 2.1kB  package.json               
npm notice === Tarball Details === 
npm notice name:          oas-normalize                           
npm notice version:       9.0.0                                   
npm notice filename:      oas-normalize-9.0.0.tgz                 
npm notice package size:  11.7 kB                                 
npm notice unpacked size: 63.9 kB                                 
npm notice shasum:        fecf0a75a4b60e53a1edb3e76c20e2fa3449e969
npm notice integrity:     sha512-fufnnQmvgXpMa[...]GBLcbvNAiCfzw==
npm notice total files:   19                                      
```

Instead of 2MB(the images were also included), it will just be a couple of KBs.
