### PR TITLE
fix: get exports working in TS `nodeNext`

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,22 +2,21 @@
   "name": "oas-normalize",
   "version": "10.0.0",
   "description": "Tooling for converting, validating, and parsing OpenAPI, Swagger, and Postman API definitions",
+  "type": "module",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "require": "./dist/index.js",
-      "import": "./dist/index.mjs"
+      "require": "./dist/index.cjs",
+      "import": "./dist/index.js"
     },
     "./lib/utils": {
-      "types": "./dist/lib/utils.d.ts",
-      "require": "./dist/lib/utils.js",
-      "import": "./dist/lib/utils.mjs"
+      "require": "./dist/lib/utils.cjs",
+      "import": "./dist/lib/utils.js"
     },
     "./package.json": "./package.json"
   },
-  "main": "dist/index.js",
-  "module": "dist/index.mjs",
-  "types": "dist/index.d.ts",
+  "main": "dist/index.cjs",
+  "module": "dist/index.js",
+  "types": "dist/index.d.cts",
   "engines": {
     "node": ">=18"
   },


### PR DESCRIPTION
## 🧰 Changes

See https://github.com/readmeio/oas/pull/796 for a further description on this fix.

## 🧬 QA & Testing

I also confirmed this fix by `npm link`-ing with `rdme`.
