### PR TITLE
fix: reorganize exports to get default export working

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -6,8 +6,8 @@ import path from 'node:path';
 import fetchMock from 'fetch-mock';
 import { describe, afterEach, beforeAll, beforeEach, it, expect } from 'vitest';
 
-import OASNormalize, { getAPIDefinitionType, isAPIDefinition } from '../src';
-import { isOpenAPI, isPostman, isSwagger } from '../src/lib/utils';
+import OASNormalize from '../src';
+import { getAPIDefinitionType, isAPIDefinition, isOpenAPI, isPostman, isSwagger } from '../src/lib/utils';
 
 function cloneObject(obj) {
   return JSON.parse(JSON.stringify(obj));

--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
       "require": "./dist/index.cjs",
       "import": "./dist/index.js"
     },
+    "./lib/types": {
+      "require": "./dist/lib/types.cjs",
+      "import": "./dist/lib/types.js"
+    },
     "./lib/utils": {
       "require": "./dist/lib/utils.cjs",
       "import": "./dist/lib/utils.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,14 +8,7 @@ import postmanToOpenAPI from '@readme/postman-to-openapi';
 import converter from 'swagger2openapi';
 
 import * as utils from './lib/utils';
-
-export interface Options {
-  colorizeErrors?: boolean;
-  enablePaths?: boolean;
-}
-
-export const isAPIDefinition = utils.isAPIDefinition;
-export const getAPIDefinitionType = utils.getAPIDefinitionType;
+import { Options } from './lib/types';
 
 export default class OASNormalize {
   cache: {
@@ -215,7 +208,7 @@ export default class OASNormalize {
    */
   version() {
     return this.load().then(schema => {
-      switch (getAPIDefinitionType(schema)) {
+      switch (utils.getAPIDefinitionType(schema)) {
         case 'openapi':
           return {
             specification: 'openapi',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import type { Options } from './lib/types';
 import type { OpenAPI } from 'openapi-types';
 
 import fs from 'node:fs';
@@ -8,7 +9,6 @@ import postmanToOpenAPI from '@readme/postman-to-openapi';
 import converter from 'swagger2openapi';
 
 import * as utils from './lib/utils';
-import { Options } from './lib/types';
 
 export default class OASNormalize {
   cache: {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,4 @@
+export interface Options {
+  colorizeErrors?: boolean;
+  enablePaths?: boolean;
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,12 +9,11 @@ export default defineConfig((options: Options) => ({
   cjsInterop: true,
   clean: true,
   dts: true,
-  entry: ['src/lib/utils.ts', 'src/index.ts'],
+  entry: ['src/index.ts', 'src/lib/types.ts', 'src/lib/utils.ts'],
   format: ['esm', 'cjs'],
   minify: false,
   shims: true,
   silent: !options.watch,
   sourcemap: true,
   splitting: true,
-  treeshake: true,
 }));


### PR DESCRIPTION
## 🧰 Changes

This fixes up our default export to get this library working in modern CommonJS again.

## 🧬 QA & Testing

See the **[Are The Types Wrong](https://arethetypeswrong.github.io/)** before/after results below:

<img width="733" alt="CleanShot 2023-09-25 at 18 12 53@2x" src="https://github.com/readmeio/oas-normalize/assets/8854718/34dbbd44-33a7-47c1-be05-6d9141d32302">


<img width="886" alt="CleanShot 2023-09-25 at 18 12 18@2x" src="https://github.com/readmeio/oas-normalize/assets/8854718/a770384c-dbec-42fe-b1d1-c78e46a5a6be">

